### PR TITLE
Bug1446966 - more improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ exports.secrets = new Secrets({
      {env: 'AWS_SECRET_ACCESS_KEY', cfg: 'aws.secretAccessKey'},
    ],
   },
-);
+});
 ```
 
 Then, in a global, async `setup` function, set it up (using a sticky loader):
 
 ```javascript
 suiteSetup(async function() {
-  const cfg = await load('cfg');
-  await exports.secrets.setup({cfg});
+  const cfg = await exports.load('cfg');
+  await exports.secrets.setup(cfg);
 });
 ```
 
@@ -152,15 +152,18 @@ exports.load = load;
 const {secrets, load} = require('./helper');
 
 secrets.mockSuite('pingdom updates', ['pingdom'], function(mock) {
-  const pingdomUpdater = new PingdomUpdater({apiKey: mock ? 'pretendKey' : secrets.get('pingdom').apiKey});
-  if (mock) {
-    suiteSetup(function() {
-      nock('https://pingdom.com:443', ..); // mock out Pingdom API
-    });
-    suiteTeardown(function() {
-      nock.clearAll();
-    });
-  }
+  let pingdomUpdater;
+  suiteSetup(function() {
+    pingdomUpdater = new PingdomUpdater({apiKey: mock ? 'pretendKey' : secrets.get('pingdom').apiKey});
+    if (mock) {
+      suiteSetup(function() {
+        nock('https://pingdom.com:443', ..); // mock out Pingdom API
+      });
+      suiteTeardown(function() {
+        nock.clearAll();
+      });
+    }
+  });
 
   test('updates once', function() { .. });
 });

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The secrets object has a few useful methods, all of which can only be called *af
 * `secrets.get(name)` -- returns an object containing the secret values by name, or throws an error if not avaialble
 * `secrets.mockSuite(title, [secrets], async function(mock) { .. })` -- run the given suite of tests both with and without mocks, skipping the real tests if all given secrets are not available.
   The `mock` parameter is true for the mock version, and false for the real version.
-  If `$NO_SKIP_TESTS` is set, then this will throw an error for each test when secrets are not available.
+  If `$NO_TEST_SKIP` is set, then this will throw an error for each test when secrets are not available.
 
 If a secret is defined in the loaded configuration, that value will be used even if the `env` key is also set.
 Secrets should not have any value set in `config.yml`, or this class will not function properly.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,8 @@ const {stickyLoader} = require('taskcluster-lib-testing');
 const load = require('../src/server');
 
 exports.load = stickyLoader(load);
-
-suiteSetup(await function() {
-  exports.load.inject('profile', 'test');
-  exports.load.inject('process', 'test');
-  await exports.load('cfg');
-});
+exports.load.inject('profile', 'test');
+exports.load.inject('process', 'test');
 ```
 
 The `load.inject(component, value)` method sets a loader overwrite without

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -92,8 +92,8 @@ class Secrets {
 
     suite(`${title} (mock)`, function() {
       suiteSetup(async function() {
-        that.load.save();
         await that.setup();
+        that.load.save();
       });
 
       fn(true);
@@ -105,8 +105,8 @@ class Secrets {
 
     suite(`${title} (real)`, function() {
       suiteSetup(async function() {
-        that.load.save();
         await that.setup();
+        that.load.save();
 
         if (!secretList.every(name => that.have(name))) {
           if (process.env.NO_TEST_SKIP) {

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -87,8 +87,8 @@ class Secrets {
     suite(`${title} (real)`, function() {
       suiteSetup(function() {
         if (!secretList.every(name => that.have(name))) {
-          if (process.env.NO_SKIP_TESTS) {
-            throw new Error(`secrets missing and NO_SKIP_TESTS is set: ${secretList.join(' ')}`);
+          if (process.env.NO_TEST_SKIP) {
+            throw new Error(`secrets missing and NO_TEST_SKIP is set: ${secretList.join(' ')}`);
           }
           this.skip();
         }

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -96,7 +96,7 @@ class Secrets {
         that.load.save();
       });
 
-      fn(true);
+      fn.call(this, true);
 
       suiteTeardown(function() {
         that.load.restore();
@@ -126,7 +126,7 @@ class Secrets {
         });
       });
 
-      fn(false);
+      fn.call(this, false);
 
       suiteTeardown(function() {
         that.load.restore();

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -38,7 +38,7 @@ class Secrets {
             cfg = await this.load('cfg');
           }
           const value = _.get(cfg, secret.cfg);
-          if (value) {
+          if (value !== undefined) {
             secret.value = value;
             continue;
           }
@@ -70,7 +70,7 @@ class Secrets {
     assert(this._setupComplete, 'must call secrets.setup() in a setup function first, or use mockSuite');
     assert(this.secrets[secret], `no such secret ${secret}`);
     const secrets = this.secrets[secret];
-    return secrets.every(secret => !!secret.value);
+    return secrets.every(secret => 'value' in secret);
   }
 
   get(secret) {
@@ -80,7 +80,7 @@ class Secrets {
     const result = {};
 
     secrets.forEach(secret => {
-      assert(secret.value, `no value found for secret ${secret.name}`);
+      assert('value' in secret, `no value found for secret ${secret.name}`);
       result[secret.name] = secret.value;
     });
 

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -89,14 +89,16 @@ class Secrets {
 
   mockSuite(title, secretList, fn) {
     const that = this;
+    let skipping = false;
 
     suite(`${title} (mock)`, function() {
       suiteSetup(async function() {
+        skipping = false;
         await that.setup();
         that.load.save();
       });
 
-      fn.call(this, true);
+      fn.call(this, true, () => skipping);
 
       suiteTeardown(function() {
         that.load.restore();
@@ -112,7 +114,10 @@ class Secrets {
           if (process.env.NO_TEST_SKIP) {
             throw new Error(`secrets missing and NO_TEST_SKIP is set: ${secretList.join(' ')}`);
           }
+          skipping = true;
           this.skip();
+        } else {
+          skipping = false;
         }
 
         // update the loader's cfg for every secret that has a cfg property; this will be restored
@@ -126,7 +131,7 @@ class Secrets {
         });
       });
 
-      fn.call(this, false);
+      fn.call(this, false, () => skipping);
 
       suiteTeardown(function() {
         that.load.restore();

--- a/src/stickyloader.js
+++ b/src/stickyloader.js
@@ -1,8 +1,22 @@
-module.exports = (load) => {
+const _ = require('lodash');
+const assert = require('assert');
+
+const stickyLoader = load => {
   let overwrites = {};
+  const stack = [];
+
+  // clone the overwrites, careful to do a shallow clone everything except cfg,
+  // which gets a deep clone so it can be modified in place.
+  const _cloneOverwrites = overwrites => {
+    const rv = _.clone(overwrites);
+    if (overwrites.cfg) {
+      rv.cfg = _.cloneDeep(overwrites.cfg);
+    }
+    return rv;
+  };
 
   /* load, storing the loaded component */
-  const wrapper = async (component, _overwrites) => {
+  const sticky = async (component, _overwrites) => {
     if (_overwrites) {
       throw new Error('Do not call stickyLoader with overwrites (a second argument)');
     }
@@ -11,15 +25,34 @@ module.exports = (load) => {
     return value;
   };
 
-  /* "unstick" everything */
-  wrapper.reset = () => {
-    overwrites = {};
+  // save the current state of the loader, for later `restore`. Saves
+  // and restores operate on a stack, in LIFO order.
+  sticky.save = () => {
+    stack.push(_cloneOverwrites(overwrites));
   };
 
-  /* inject a dependency */
-  wrapper.inject = (component, value) => {
+  // restore to the save point at the top of the stack
+  sticky.restore = () => {
+    overwrites = stack.pop();
+  };
+
+  // edit the cfg component in-place, at the given dotted path
+  sticky.cfg = (path, value) => {
+    assert('cfg' in overwrites, 'cannot call `load.cfg` until the `cfg` component is loaded');
+    _.set(overwrites['cfg'], path, value);
+  };
+
+  // inject a dependency
+  sticky.inject = (component, value) => {
     overwrites[component] = value;
   };
 
-  return wrapper;
+  // remove a dependency
+  sticky.remove = component => {
+    delete overwrites[component];
+  };
+
+  return sticky;
 };
+
+module.exports = stickyLoader;

--- a/src/stickyloader.js
+++ b/src/stickyloader.js
@@ -33,6 +33,7 @@ const stickyLoader = load => {
 
   // restore to the save point at the top of the stack
   sticky.restore = () => {
+    assert(stack.length > 0, 'unbalanced load.save/restore');
     overwrites = stack.pop();
   };
 

--- a/test/secrets_test.js
+++ b/test/secrets_test.js
@@ -93,6 +93,13 @@ suite('Secrets', function() {
       assert.deepEqual(secrets.get('envAndCfg'), {PASS_IN_BOTH: 'P2'});
     });
 
+    test('have with a false value', async function() {
+      sticky.inject('cfg', {cfgonly: {pass: false}});
+      await secrets.setup();
+      assert(secrets.have('cfgOnly'));
+      assert.deepEqual(secrets.get('cfgOnly'), {cfgonly: false});
+    });
+
     test('with env', async function() {
       process.env.PASS_IN_ENV = 'PIE';
       process.env.PASS_IN_BOTH = 'PIB';

--- a/test/secrets_test.js
+++ b/test/secrets_test.js
@@ -146,7 +146,7 @@ suite('Secrets', function() {
       assert.deepEqual(testsRun, [true, false], 'expected both runs');
     });
   });
-  // NOTE: testing NO_SKIP_TESTS would generate a failed test, so we do not attempt to test that.
+  // NOTE: testing NO_TEST_SKIP would generate a failed test, so we do not attempt to test that.
 
   suite('_fetchSecrets', function() {
     const secrets = new Secrets({

--- a/test/stickyloader_test.js
+++ b/test/stickyloader_test.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const assert = require('assert');
 const {stickyLoader} = require('../');
 
@@ -47,21 +48,60 @@ suite('stickyLoader', function() {
     }]);
   });
 
-  test('reset resets', async function() {
+  test('cfg fails if cfg is not loaded', async function() {
+    try {
+      sticky.cfg('app.secret', 'donttell');
+    } catch (e) {
+      assert(e.toString().match(/AssertionError/), `got ${e}`);
+      return;
+    }
+    assert(false, 'expected error');
+  });
+
+  test('cfg', async function() {
+    sticky.inject('cfg', {});
+    sticky.cfg('a.b.c', 'd');
+    assert(_.isEqual(await sticky('cfg'), {a: {b: {c: 'd'}}}));
+  });
+
+  test('save/restore', async function() {
     const first = await sticky('abc');
+    sticky.save();
     const second = await sticky('def');
-    sticky.reset();
-    const third = await sticky('abc');
-    assert.deepEqual(loads, [{
-      component: 'abc',
-      overwrites: [],
-    }, {
-      component: 'def',
-      overwrites: ['abc'],
-    }, {
-      component: 'abc',
-      overwrites: [],
-    }]);
-    assert(first !== third);
+    assert(await sticky('abc') === first, 'abc should be the same object');
+    (await sticky('abc')).updated = true;
+    sticky.restore();
+    assert(await sticky('def') !== second, 'def should be a different object');
+    assert((await sticky('abc')).updated, 'in-place modification to abc persists');
+  });
+
+  test('save/restore with inject', async function() {
+    sticky.inject('abc', 'AAA');
+    sticky.save();
+    sticky.inject('abc', 'BBB');
+    assert(await sticky('abc') === 'BBB', 'should get the updated injected value');
+    sticky.restore();
+    assert(await sticky('abc') === 'AAA', 'should get the original injected value');
+  });
+
+  test('save/restore with remove', async function() {
+    sticky.inject('abc', 'AAA');
+    sticky.save();
+    sticky.remove('abc');
+    assert(_.isEqual(await sticky('abc'), {component: 'abc'}), 'should load abc from loader');
+    sticky.restore();
+    assert(await sticky('abc') === 'AAA', 'should get the original injected value');
+  });
+
+  test('save/restore with cfg', async function() {
+    sticky.inject('cfg', {});
+    sticky.cfg('app.secret', 'donttell');
+    assert((await sticky('cfg')).app.secret === 'donttell');
+    sticky.save();
+    assert((await sticky('cfg')).app.secret === 'donttell');
+    sticky.cfg('app.secret', 'Fae9ce3z');
+    assert((await sticky('cfg')).app.secret === 'Fae9ce3z');
+    sticky.restore();
+    assert((await sticky('cfg')).app.secret === 'donttell');
   });
 });


### PR DESCRIPTION
I have rewritten the tests for hooks and secrets, and learned some things.

* Mocha has bugs around skipping
* stickyLoader needed more functionality - in particular, some special-casing for modifying `cfg`, and the ability to save and restore on entry to and exit from a suite.
* Secrets can integrate closely with stickyLoader to handle most of those details for you..