### PR TITLE
Allow providing values for missing secrets in mock mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ exports.secrets = new Secrets({
      // env - the environment variable by which this secret is set in the config (if any)
      // cfg - dotted path to the config value containing this secret (if any)
      // name - name for the secret (used for programmatic access in tests; defaults to env)
-     {env: 'PULSE_USERNAME', cfg: 'pulse.username', name: 'username'},
+     // mock - value to provide if secret is not set (for mock runs only)
+     {env: 'PULSE_USERNAME', cfg: 'pulse.username', name: 'username', mock: 'dummy'},
      {env: 'PULSE_PASSWORD', cfg: 'pulse.password', name: 'password'},
    ],
    aws: [

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -102,6 +102,15 @@ class Secrets {
         skipping = false;
         await that.setup();
         that.load.save();
+
+        // update the loader's cfg with `mock` default values
+        secretList.forEach(name => {
+          that.secrets[name].forEach(secret => {
+            if (secret.cfg && secret.mock) {
+              that.load.cfg(secret.cfg, secret.mock);
+            }
+          });
+        });
       });
 
       fn.call(this, true, () => skipping);


### PR DESCRIPTION
This is useful to provide a rootUrl for schema generation.