### PR TITLE
only parse when the request body isn't already parsed

### DIFF
--- a/src/fakeauth.js
+++ b/src/fakeauth.js
@@ -14,7 +14,10 @@ exports.start = function(clients, {rootUrl}={}) {
     .filteringRequestBody(/.*/, '*')
     .post(authPath, '*')
     .reply(200, function(uri, requestBody) {
-      let body = JSON.parse(requestBody);
+      let body = requestBody;
+      if (typeof requestBody !== 'object') {
+        body = JSON.parse(requestBody);
+      }
       let scopes = [];
       let from = 'client config';
       let ext = null;


### PR DESCRIPTION
Not sure why this is needed, but sometimes the request body is
already parsed as json into an object.